### PR TITLE
Added support for multiple videos on one Edx page

### DIFF
--- a/edX Super Speed.user.js
+++ b/edX Super Speed.user.js
@@ -9,18 +9,20 @@
 // @run-at document-idle
 // ==/UserScript==
 
-(function() {
-    'use strict';
-    var vid = document.getElementsByClassName("video")[0];
+function addDownloadButton(vid)
+{
     var vid_url = vid.attributes['data-metadata'].value.toString().match("https://edx-video.net/[\\w\-\.]+.mp4")[0];
     var vid_title = vid.previousElementSibling.innerText;
     var zNode = document.createElement ('div');
+    var pn = vid.parentNode;
     zNode.innerHTML = '<button id="myButton" type="button"><a href=' + vid_url + '>Download ' + vid_title + ' lecture video</a></button>';
     zNode.setAttribute ('id', 'myContainer');
-    zNode.style = "top:0;right:0;position:absolute;z-index:99999;padding:20px;";
-    document.body.appendChild (zNode);
+    zNode.style = "padding-bottom:5px;";
+    pn.insertBefore (zNode, vid); // Insert button just above this video
+};
 
-    var item = document.getElementsByClassName("video-speeds")[0];
+function addSuperSpeeds(vid_speed)
+{
     var new_speed = document.createElement("li");
     var btn = document.createElement("button");
     var speed_limit = "2.0";
@@ -30,9 +32,8 @@
     new_speed.appendChild(btn);
     new_speed.setAttribute("data-speed", speed_limit);
     new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
+    vid_speed.prepend(new_speed);
 
-    item = document.getElementsByClassName("video-speeds")[0];
     new_speed = document.createElement("li");
     btn = document.createElement("button");
     speed_limit = "2.5";
@@ -42,9 +43,8 @@
     new_speed.appendChild(btn);
     new_speed.setAttribute("data-speed", speed_limit);
     new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
+    vid_speed.prepend(new_speed);
 
-    item = document.getElementsByClassName("video-speeds")[0];
     new_speed = document.createElement("li");
     btn = document.createElement("button");
     speed_limit = "3.0";
@@ -54,9 +54,8 @@
     new_speed.appendChild(btn);
     new_speed.setAttribute("data-speed", speed_limit);
     new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
+    vid_speed.prepend(new_speed);
 
-    item = document.getElementsByClassName("video-speeds")[0];
     new_speed = document.createElement("li");
     btn = document.createElement("button");
     speed_limit = "4.0";
@@ -66,8 +65,17 @@
     new_speed.appendChild(btn);
     new_speed.setAttribute("data-speed", speed_limit);
     new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
+    vid_speed.prepend(new_speed);
+}
 
+(function() {
+    'use strict';
+    var vids = document.getElementsByClassName("video");
+    [].forEach.call(vids, addDownloadButton);
+
+    var vid_speeds = document.getElementsByClassName("video-speeds");
+    [].forEach.call(vid_speeds, addSuperSpeeds);
+    
     const keySpace = 32;
     const keyLeft = 37;
     const keyRight = 39;


### PR DESCRIPTION
The Linear Algebra class often has multiple videos on one page. The current script only adds faster speeds to the first video. This adds the faster speeds, as well as the download button, to **_all_** videos that appears on a page.

I didn't do anything to the video controls code, so that will still only work for the first video, I think? 