### PR TITLE
Remove the duplicate 2x speed option

### DIFF
--- a/edX Super Speed.user.js
+++ b/edX Super Speed.user.js
@@ -14,7 +14,7 @@
     var item = document.getElementsByClassName("video-speeds")[0];
     var new_speed = document.createElement("li");
     var btn = document.createElement("button");
-    var speed_limit = "2.5";
+    var speed_limit = "2.50";
     btn.setAttribute("class", "control speed-option");
     btn.setAttribute("tabindex", -1);
     btn.setAttribute("aria-pressed", "false");

--- a/edX Super Speed.user.js
+++ b/edX Super Speed.user.js
@@ -14,19 +14,7 @@
     var item = document.getElementsByClassName("video-speeds")[0];
     var new_speed = document.createElement("li");
     var btn = document.createElement("button");
-    var speed_limit = "2.0";
-    btn.setAttribute("class", "control speed-option");
-    btn.setAttribute("tabindex", -1);
-    btn.setAttribute("aria-pressed", "false");
-    new_speed.appendChild(btn);
-    new_speed.setAttribute("data-speed", speed_limit);
-    new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
-
-    item = document.getElementsByClassName("video-speeds")[0];
-    new_speed = document.createElement("li");
-    btn = document.createElement("button");
-    speed_limit = "2.5";
+    var speed_limit = "2.5";
     btn.setAttribute("class", "control speed-option");
     btn.setAttribute("tabindex", -1);
     btn.setAttribute("aria-pressed", "false");


### PR DESCRIPTION
Makes two fixes:
* Edx now adds the 2x speed by default, so no need to double up.
* Also now shows when 2.5x speed is selected

![image](https://user-images.githubusercontent.com/3886640/111570147-88741180-877a-11eb-888c-6b046643f43e.png)
